### PR TITLE
autoupdate: Fix AC_PROG_LIBTOOL obsolete warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,11 +19,11 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-AC_PREREQ(2.59)
+AC_PREREQ([2.71])
 AC_INIT([cbm],[0.3],[https://github.com/resurrecting-open-source-projects/cbm/issues])
 AM_INIT_AUTOMAKE(foreign)
 AC_CONFIG_SRCDIR(src/cbm.cpp)
-AC_CONFIG_HEADER(src/config.h)
+AC_CONFIG_HEADERS([src/config.h])
 
 # Checks for programs.
 AC_PROG_CC
@@ -31,7 +31,7 @@ AC_PROG_CXX
 if test "${GXX}" = ""; then
     AC_MSG_ERROR([ERROR: we need a C++ compiler, like g++ or other])
 fi
-AC_PROG_LIBTOOL
+LT_INIT
 
 # Check for host platform
 AC_CANONICAL_HOST


### PR DESCRIPTION
I was packaging cbm to ArchLinux and during my testings `./autogen.sh` printed:

```
configure.ac:34: warning: The macro `AC_PROG_LIBTOOL' is obsolete.
configure.ac:34: You should run autoupdate.
m4/libtool.m4:99: AC_PROG_LIBTOOL is expanded from...
```

I executed `autoupdate` and it compiled without warnings.

**Note**: I only tested it against ArchLinux and I don't know how this change affects other distributions and theirs libs versions.